### PR TITLE
Remove tasks section from PBI template and update default formatter

### DIFF
--- a/.github/ISSUE_TEMPLATE/pbi-simple-template.md
+++ b/.github/ISSUE_TEMPLATE/pbi-simple-template.md
@@ -15,10 +15,5 @@ assignees: ''
 - [ ] Acceptance Criterion 1  
 - [ ] Acceptance Criterion 2  
 
-## Tasks  
-<!-- List the tasks (specific work items) required for developers to complete this PBI in a checklist format. -->  
-- [ ] Task 1  
-- [ ] Task 2  
-
 ## Other  
 <!-- Include here any related documents, similar past PBIs, notes, or remarks related to this PBI. -->

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "MD041": false
   },
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "biomejs.biome",
   "[javascript]": {
     "editor.defaultFormatter": "biomejs.biome"
   },
@@ -21,5 +21,14 @@
   "editor.codeActionsOnSave": {
     "quickfix.biome": "always",
     "source.organizeImports.biome": "always"
+  },
+  "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
+    {
+      "file": "pull_request_template.md",
+      "prompt": "Generate a pull request description using the structure and headings defined in the provided template. Fill in each section with appropriate and concise content based on the code changes. Use clear and professional language."
+    }
+  ],
+  "[jsonc]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
   }
 }


### PR DESCRIPTION
Eliminate the tasks section from the PBI template to streamline the format. Update the default code formatter to biomejs and add instructions for generating pull request descriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Streamlined the work item template by removing outdated task checklists.
- **Chores**
	- Enhanced development environment settings with a new default formatter.
	- Introduced configuration to support GitHub Copilot chat for generating pull request descriptions.
	- Added dedicated formatting support for JSON-like content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->