### PR TITLE
feat: migrate apps and blogs config to external JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # React Router
 /.react-router/
 /build/
+
+.serena
+.tmp

--- a/app/config/apps-config.ts
+++ b/app/config/apps-config.ts
@@ -1,3 +1,5 @@
+import appsJson from '../../contents/apps.json' with { type: 'json' };
+
 export interface AppItem {
   title: string;
   icon?: string; // Change to string for URL
@@ -7,34 +9,6 @@ export interface AppItem {
   tags: string[];
 }
 
-export const apps: AppItem[] = [
-  {
-    title: 'MangaLog',
-    icon: 'https://github.com/atman-33/manga-log/blob/main/public/favicons/favicon-32x32.png?raw=true',
-    description: 'Track & Organize Your Manga Reading Journey',
-    imageUrl:
-      'https://raw.githubusercontent.com/atman-33/manga-log/refs/heads/main/public/ogp-image.png',
-    appUrl: 'https://mangalogs.com/',
-    tags: ['Manga', 'Tracker', 'Reading Log'],
-  },
-  {
-    title: 'TubeLoopPlayer',
-    icon: 'https://raw.githubusercontent.com/atman-33/tube-loop-player/refs/heads/main/public/favicons/favicon-32x32.png',
-    description: 'Loop & Playlist Your Favorite YouTube Videos',
-    imageUrl:
-      'https://raw.githubusercontent.com/atman-33/tube-loop-player/refs/heads/main/public/ogp-image.png',
-    appUrl: 'https://tubeloopplayer.com/',
-    tags: ['YouTube', 'Music', 'Video Player'],
-  },
-  {
-    title: 'Double-Click Image Opener',
-    icon: 'https://tech-bridge-log.com/icons/tags/obsidian.svg',
-    description:
-      'Obsidian plugin to open images in your default system viewer by double-clicking them.',
-    imageUrl:
-      'https://raw.githubusercontent.com/atman-33/double-click-image-opener/refs/heads/main/images/double-click-image-to-open.png',
-    appUrl:
-      'https://github.com/atman-33/double-click-image-opener?tab=readme-ov-file#readme',
-    tags: ['Obsidian', 'Plugin', 'Image Viewer'],
-  },
-];
+const appsData = appsJson as AppItem[];
+
+export const apps = appsData;

--- a/app/config/apps-config.ts
+++ b/app/config/apps-config.ts
@@ -3,7 +3,7 @@ export interface AppItem {
   icon?: string; // Change to string for URL
   description: string;
   imageUrl: string;
-  demoUrl: string;
+  appUrl: string;
   tags: string[];
 }
 
@@ -14,7 +14,7 @@ export const apps: AppItem[] = [
     description: 'Track & Organize Your Manga Reading Journey',
     imageUrl:
       'https://raw.githubusercontent.com/atman-33/manga-log/refs/heads/main/public/ogp-image.png',
-    demoUrl: 'https://mangalogs.com/',
+    appUrl: 'https://mangalogs.com/',
     tags: ['Manga', 'Tracker', 'Reading Log'],
   },
   {
@@ -23,7 +23,7 @@ export const apps: AppItem[] = [
     description: 'Loop & Playlist Your Favorite YouTube Videos',
     imageUrl:
       'https://raw.githubusercontent.com/atman-33/tube-loop-player/refs/heads/main/public/ogp-image.png',
-    demoUrl: 'https://tubeloopplayer.com/',
+    appUrl: 'https://tubeloopplayer.com/',
     tags: ['YouTube', 'Music', 'Video Player'],
   },
   {
@@ -33,7 +33,7 @@ export const apps: AppItem[] = [
       'Obsidian plugin to open images in your default system viewer by double-clicking them.',
     imageUrl:
       'https://raw.githubusercontent.com/atman-33/double-click-image-opener/refs/heads/main/images/double-click-image-to-open.png',
-    demoUrl:
+    appUrl:
       'https://github.com/atman-33/double-click-image-opener?tab=readme-ov-file#readme',
     tags: ['Obsidian', 'Plugin', 'Image Viewer'],
   },

--- a/app/config/blogs-config.ts
+++ b/app/config/blogs-config.ts
@@ -1,3 +1,5 @@
+import blogsJson from '../../contents/blogs.json' with { type: 'json' };
+
 export interface BlogItem {
   title: string;
   description: string;
@@ -5,35 +7,25 @@ export interface BlogItem {
   image?: string;
 }
 
-export const blogs: BlogItem[] = [
-  {
-    title: 'Medium Articles',
-    description: 'Technical writing in English',
-    url: 'https://medium.com/@gpbjk0304',
-    image: `${import.meta.env.BASE_URL}images/Medium-Wordmark-Black.svg`,
-  },
-  {
-    title: 'DEV Articles',
-    description: 'Technical writing and development logs on DEV Community',
-    url: 'https://dev.to/atman33',
-    image: `${import.meta.env.BASE_URL}images/dev-badge.svg`,
-  },
-  {
-    title: 'note Articles',
-    description: 'General writing in Japanese',
-    url: 'https://note.com/atman33',
-    image: `${import.meta.env.BASE_URL}images/note-logo.svg`,
-  },
-  {
-    title: 'Zenn Articles',
-    description: 'Technical writing in Japanese',
-    url: 'https://zenn.dev/atman',
-    image: `${import.meta.env.BASE_URL}images/Zenn-logo.png`,
-  },
-  {
-    title: 'izanami Articles',
-    description: 'Technical writing in Japanese',
-    url: 'https://izanami.dev/user/bfdb45af-4adf-4994-aca7-595f2228fb88',
-    image: `${import.meta.env.BASE_URL}images/izanami-logo.svg`,
-  },
-];
+const resolveBlogImage = (image?: string) => {
+  if (!image) {
+    return undefined;
+  }
+
+  if (/^https?:\/\//.test(image)) {
+    return image;
+  }
+
+  const basePath = import.meta.env.BASE_URL.endsWith('/')
+    ? import.meta.env.BASE_URL
+    : `${import.meta.env.BASE_URL}/`;
+
+  return `${basePath}${image.replace(/^\//, '')}`;
+};
+
+const blogsData = blogsJson as BlogItem[];
+
+export const blogs = blogsData.map((blog) => ({
+  ...blog,
+  image: resolveBlogImage(blog.image),
+}));

--- a/app/routes/_app._tab._apps._index/components/app-card.tsx
+++ b/app/routes/_app._tab._apps._index/components/app-card.tsx
@@ -89,7 +89,7 @@ export function AppCard({ app, isLoading = false }: AppCardProps) {
       <div className="absolute inset-0 bg-gradient-to-r from-purple-500/10 to-pink-500/10 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
 
       <a
-        href={app.demoUrl}
+        href={app.appUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="absolute inset-0 z-20"

--- a/contents/apps.json
+++ b/contents/apps.json
@@ -1,0 +1,26 @@
+[
+  {
+    "title": "MangaLog",
+    "icon": "https://github.com/atman-33/manga-log/blob/main/public/favicons/favicon-32x32.png?raw=true",
+    "description": "Track & Organize Your Manga Reading Journey",
+    "imageUrl": "https://raw.githubusercontent.com/atman-33/manga-log/refs/heads/main/public/ogp-image.png",
+    "appUrl": "https://mangalogs.com/",
+    "tags": ["Manga", "Tracker", "Reading Log"]
+  },
+  {
+    "title": "TubeLoopPlayer",
+    "icon": "https://raw.githubusercontent.com/atman-33/tube-loop-player/refs/heads/main/public/favicons/favicon-32x32.png",
+    "description": "Loop & Playlist Your Favorite YouTube Videos",
+    "imageUrl": "https://raw.githubusercontent.com/atman-33/tube-loop-player/refs/heads/main/public/ogp-image.png",
+    "appUrl": "https://tubeloopplayer.com/",
+    "tags": ["YouTube", "Music", "Video Player"]
+  },
+  {
+    "title": "Double-Click Image Opener",
+    "icon": "https://tech-bridge-log.com/icons/tags/obsidian.svg",
+    "description": "Obsidian plugin to open images in your default system viewer by double-clicking them.",
+    "imageUrl": "https://raw.githubusercontent.com/atman-33/double-click-image-opener/refs/heads/main/images/double-click-image-to-open.png",
+    "appUrl": "https://github.com/atman-33/double-click-image-opener?tab=readme-ov-file#readme",
+    "tags": ["Obsidian", "Plugin", "Image Viewer"]
+  }
+]

--- a/contents/blogs.json
+++ b/contents/blogs.json
@@ -1,0 +1,32 @@
+[
+  {
+    "title": "Medium Articles",
+    "description": "Technical writing in English",
+    "url": "https://medium.com/@gpbjk0304",
+    "image": "images/Medium-Wordmark-Black.svg"
+  },
+  {
+    "title": "DEV Articles",
+    "description": "Technical writing and development logs on DEV Community",
+    "url": "https://dev.to/atman33",
+    "image": "images/dev-badge.svg"
+  },
+  {
+    "title": "note Articles",
+    "description": "General writing in Japanese",
+    "url": "https://note.com/atman33",
+    "image": "images/note-logo.svg"
+  },
+  {
+    "title": "Zenn Articles",
+    "description": "Technical writing in Japanese",
+    "url": "https://zenn.dev/atman",
+    "image": "images/Zenn-logo.png"
+  },
+  {
+    "title": "izanami Articles",
+    "description": "Technical writing in Japanese",
+    "url": "https://izanami.dev/user/bfdb45af-4adf-4994-aca7-595f2228fb88",
+    "image": "images/izanami-logo.svg"
+  }
+]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "types": ["node", "vite/client"],
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "ESNext",
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],


### PR DESCRIPTION
Refactor apps-config.ts and blogs-config.ts to import data from external JSON files instead of hardcoding arrays. This improves maintainability by separating data from code.

- Add .serena and .tmp to gitignore for local development files
- Update TypeScript module setting from ES2022 to ESNext for JSON imports
- Implement image URL resolution logic for blog items
- Remove hardcoded app and blog arrays in favor of JSON imports

## Overview  
<!-- Briefly describe the purpose of this Pull Request. -->

## Changes  

- Change 1  
- Change 2  
- Change 3  

## Related Issue  

- Issue number (e.g., #123)  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Updated Apps catalog with three new entries (titles, icons, descriptions, tags) and links now point to live app URLs.
  * Refreshed Blogs list with five curated entries.

* Bug Fixes
  * Blog images now load reliably via automatic resolution of relative and absolute URLs.

* Chores
  * Added new data files for apps and blogs content.
  * Expanded .gitignore patterns.
  * Updated TypeScript module setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->