### PR TITLE
feat: reverse apps display order for chronological sorting

### DIFF
--- a/app/routes/_app._tab._apps._index/components/apps-grid.tsx
+++ b/app/routes/_app._tab._apps._index/components/apps-grid.tsx
@@ -25,7 +25,7 @@ export function AppsGrid({ apps, isLoading = false }: AppsGridProps) {
                 <AppCard isLoading />
               </div>
             ))
-        : apps.map((app, index) => (
+        : [...apps].reverse().map((app, index) => (
             <Fragment key={app.title}>
               <div
                 className="w-full max-w-sm animate-fade-in animate-duration-700"


### PR DESCRIPTION
The AppsGrid component was sorting the apps array in ascending order by default, making newer apps appear at the end. By reversing the array, newer apps now appear at the top which aligns with user expectations for chronological ordering (newest first). This improves the user experience by showing the most relevant content first.<｜begin▁of▁sentence｜>

## Overview  
<!-- Briefly describe the purpose of this Pull Request. -->

## Changes  

- Change 1  
- Change 2  
- Change 3  

## Related Issue  

- Issue number (e.g., #123)  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apps grid now displays items from right-to-left, placing the most recent apps first for quicker access to new additions.
  * The visible order of App cards after loading is reversed compared to before, affecting browsing and keyboard navigation sequence.
  * Loading placeholders remain unchanged to preserve familiar skeleton behavior.
  * No action required—behavior updates automatically for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->